### PR TITLE
Add option to toggle info labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ This file typically contains a brief description of what the user is currently
 working on. This file is intended to be updated frequently and there are no
 restrictions on what type of information the user can include.
 
+#### ``FINGER_INFO_LABELS``
+
+Set to "true" or "false" to toggle showing the 'Project:' and 'Plan:' labels
+in the response.
+
 ## Links
 
 - [RFC 742 - NAME/FINGER](https://tools.ietf.org/html/rfc742)

--- a/finger2020
+++ b/finger2020
@@ -57,6 +57,11 @@ FINGER_PLAN
     This file typically contains a brief description of what the user is
     currently working on. This file is intended to be updated frequently and
     there are no restrictions on what type of information the user can include.
+
+FINGER_INFO_LABELS
+
+    Set to "true" or "false" to toggle showing the 'Project:' and 'Plan:' labels
+    in the response.
 """
 import os
 import re
@@ -77,6 +82,7 @@ FINGER_NAME = os.getenv("FINGER_NAME", "anonymous")
 FINGER_CONTACT = os.getenv("FINGER_CONTACT", os.path.join(HOME, ".contact"))
 FINGER_PLAN = os.getenv("FINGER_PLAN", os.path.join(HOME, ".plan"))
 FINGER_PROJECT = os.getenv("FINGER_PROJECT", os.path.join(HOME, ".project"))
+FINGER_INFO_LABELS = os.getenv("FINGER_INFO_LABELS", "true")
 
 # Query specification:
 #   {Q1}    ::= [{W}|{W}{S}{U}]{C}
@@ -117,7 +123,10 @@ def render_user_info():
     contact = read_file(FINGER_CONTACT)
     project = read_file(FINGER_PROJECT)
     plan = read_file(FINGER_PLAN).strip()
-    return "\r\n".join([contact, f"Project:", project, "", f"Plan: {plan}"])
+    if FINGER_INFO_LABELS == "false":
+        return "\r\n".join([contact, project, plan])
+    else:
+        return "\r\n".join([contact, f"Project:", project, "", f"Plan: {plan}"])
 
 
 def handle(query):

--- a/systemd/finger2020.env
+++ b/systemd/finger2020.env
@@ -4,3 +4,4 @@
 # FINGER_CONTACT="/etc/finger/contact.txt"
 # FINGER_PROJECT="/etc/finger/project.txt"
 # FINGER_PLAN="/etc/finger/plan.txt"
+# FINGER_INFO_LABELS="true"


### PR DESCRIPTION
This adds an option to toggle showing the 'Project' and 'Plan' labels in
the Finger response. This is exposed via an environment variable called
`FINGER_INFO_LABELS` and is enabled by default, preserving the current
behavior.

This allows for a little more customization in the Finger output, albeit
potentially less 'standard'.

---

@michael-lazar Not sure if this is something you're interested in or if you'd prefer to leave the response as-is.